### PR TITLE
Detect user's settings for tabs vs. spaces

### DIFF
--- a/src/main/kotlin/com/mintlify/document/actions/PopupDialogAction.kt
+++ b/src/main/kotlin/com/mintlify/document/actions/PopupDialogAction.kt
@@ -38,6 +38,8 @@ public class PopupDialogAction : AnAction() {
         val languageId = if (selectedFile.extension == "py") "python" else selectedFile.fileType.displayName.lowercase()
         val width = editor.settings.getRightMargin(project) - whitespaceBeforeLine.length
         val lineText = getLineText(document, startLineNumber)
+        // Get indent size
+        val tabSize = editor.settings.getTabSize(project)
 
         val task = object : Task.Backgroundable(project, "AI doc writer progress") {
             override fun run(indicator: ProgressIndicator) {
@@ -60,7 +62,7 @@ public class PopupDialogAction : AnAction() {
                     } else {
                         document.getLineStartOffset(startLineNumber) + whitespaceBeforeLine.length
                     }
-                    val insertDoc = getFormattedInsertDoc(response.docstring, whitespaceBeforeLine, isBelowStartLine)
+                    val insertDoc = getFormattedInsertDoc(response.docstring, whitespaceBeforeLine, isBelowStartLine, tabSize)
 
                     WriteCommandAction.runWriteCommandAction(project) {
                         document.insertString(insertPosition, insertDoc)
@@ -90,12 +92,14 @@ fun getWhitespaceOfLineAtOffset(document: Document, lineNumber: Int): String {
     return getWhitespaceSpaceBefore(startLine)
 }
 
-fun getFormattedInsertDoc(docstring: String, whitespaceBeforeLine: String, isBelowStartLine: Boolean = false): String {
+fun getFormattedInsertDoc(docstring: String, whitespaceBeforeLine: String, isBelowStartLine: Boolean = false, tabSize: Int): String {
     var differingWhitespaceBeforeLine = whitespaceBeforeLine
     var lastLineWhitespace = ""
     // Format for tabbed position
     if (isBelowStartLine) {
-        differingWhitespaceBeforeLine = '\t' + differingWhitespaceBeforeLine
+        val space = " "
+        val tab = space.repeat(tabSize)
+        differingWhitespaceBeforeLine = tab + differingWhitespaceBeforeLine
     } else {
         lastLineWhitespace = differingWhitespaceBeforeLine
     }

--- a/src/main/kotlin/com/mintlify/document/actions/PopupDialogAction.kt
+++ b/src/main/kotlin/com/mintlify/document/actions/PopupDialogAction.kt
@@ -16,7 +16,7 @@ import com.intellij.openapi.progress.Task
 import com.mintlify.document.helpers.getDocFromApi
 import com.mintlify.document.ui.MyToolWindowFactory
 
-public class PopupDialogAction : AnAction() {
+class PopupDialogAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
 
         val project: Project = e.getRequiredData(CommonDataKeys.PROJECT)

--- a/src/main/kotlin/com/mintlify/document/helpers/api.kt
+++ b/src/main/kotlin/com/mintlify/document/helpers/api.kt
@@ -38,7 +38,7 @@ fun getDocFromApi(
 ): Response? {
     val source = "intellij"
     val userId = System.getProperty("user.name")
-    val body = RequestBody(userId, code, languageId, context, width, commented, email, docStyle, source, location, line);
+    val body = RequestBody(userId, code, languageId, context, width, commented, email, docStyle, source, location, line)
 
     val apiBase = "https://api.mintlify.com/docs/"
     var endpoint = apiBase + "write/v2"
@@ -54,5 +54,5 @@ fun getDocFromApi(
         return Klaxon().parse<Response>(payload)
     }
 
-    return null;
+    return null
 }


### PR DESCRIPTION
- [x] detect when i should use \t vs. spaces

<img width="685" alt="image" src="https://user-images.githubusercontent.com/55263191/154776455-cc79e9c7-7145-4da0-9b33-fafa4ce68e33.png">

# Test Plan
- In `gradle.properties`, Change `platformType` from `IC` to `PC` (for PyCharm), then runIde
<img width="633" alt="image" src="https://user-images.githubusercontent.com/55263191/155241772-a6282299-648d-4cf9-9a5a-0ad7dccc9ef9.png">

- Make sure that there's no squiggly/underline yelling about using the wrong type of indentation (tabs vs. spaces)